### PR TITLE
Added support for COT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ riderModule.iml
 /_ReSharper.Caches/
 *.DotSettings.user
 .idea/
+.aigon/*.db

--- a/SchemaDoctor.sln
+++ b/SchemaDoctor.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".meta", ".meta", "{86FFA5A9
 		Directory.Packages.props = Directory.Packages.props
 		Source\Directory.Build.props = Source\Directory.Build.props
 		readme.md = readme.md
+		.gitignore = .gitignore
 	EndProjectSection
 EndProject
 Global

--- a/Source/SchemaDoctor.Microsoft.Extensions.AI/CompletionExtensions.cs
+++ b/Source/SchemaDoctor.Microsoft.Extensions.AI/CompletionExtensions.cs
@@ -11,16 +11,13 @@ public static class CompletionExtensions
     /// </summary>
     /// <param name="completion">The completion to get the result from</param>
     /// <param name="parsed">The parsed result</param>
-    /// <param name="error">The error if the result cannot be parsed</param>
     /// <returns>True if the result can be parsed, false otherwise</returns>
     public static bool TryToGetResultWithTherapy<T>(this ChatCompletion<T> completion,
-        [NotNullWhen(true)] out T? parsed,
-        [NotNullWhen(false)] out string? error) where T : class
+        [NotNullWhen(true)] out T? parsed) where T : class
     {
         // If the default is OK, do nothing extra
         if (completion.TryGetResult(out parsed))
         {
-            error = null;
             return true;
         }
 
@@ -29,10 +26,9 @@ public static class CompletionExtensions
         if (raw is null)
         {
             parsed = default;
-            error = "No text in response";
             return false;
         }
 
-        return SchemaTherapist.TryMapToSchema(raw, out parsed, out error);
+        return SchemaTherapist.TryMapToSchema(raw, out parsed);
     }
 }

--- a/Source/SchemaDoctor.Microsoft.Extensions.AI/FunctionExtensions.cs
+++ b/Source/SchemaDoctor.Microsoft.Extensions.AI/FunctionExtensions.cs
@@ -114,7 +114,7 @@ public static class FunctionExtensions
 
                     if (methodInfo != null)
                     {
-                        var parameters = new object?[] { json, null, null, function.Metadata.JsonSerializerOptions };
+                        var parameters = new object?[] { json, null, function.Metadata.JsonSerializerOptions };
                         var success = (bool)methodInfo.Invoke(null, parameters)!;
 
                         if (success)

--- a/Source/SchemaDoctor/JsonExtractor.cs
+++ b/Source/SchemaDoctor/JsonExtractor.cs
@@ -1,0 +1,84 @@
+﻿namespace SchemaDoctor;
+
+public static class JsonExtractor
+{
+    public static ReadOnlySpan<char> ExtractJsonDocument(ReadOnlySpan<char> text, out ReadOnlySpan<char> remainingText)
+    {
+        remainingText = ReadOnlySpan<char>.Empty;
+        if (text.IsEmpty) return ReadOnlySpan<char>.Empty;
+
+        // Find the first opening brace or bracket
+        var start = text.IndexOfAny('{', '[');
+        if (start == -1) return ReadOnlySpan<char>.Empty;
+
+        // Track nesting level and string context
+        var nestingLevel = 0;
+        var inString = false;
+        var escaped = false;
+        var openChar = text[start];
+        var closeChar = openChar == '{' ? '}' : ']';
+
+        for (var i = start; i < text.Length; i++)
+        {
+            var c = text[i];
+
+            if (inString)
+            {
+                if (escaped)
+                {
+                    escaped = false;
+                    continue;
+                }
+
+                if (c == '\\')
+                {
+                    escaped = true;
+                    continue;
+                }
+
+                if (c == '"')
+                {
+                    inString = false;
+                }
+
+                continue;
+            }
+
+            switch (c)
+            {
+                case '"':
+                    inString = true;
+                    break;
+
+                case '{':
+                case '[':
+                    if (c == openChar || nestingLevel > 0)
+                    {
+                        nestingLevel++;
+                    }
+
+                    break;
+
+                case '}':
+                case ']':
+                    if ((c == closeChar && nestingLevel == 1) || (nestingLevel > 1 &&
+                                                                  ((c == '}' && text[i - 1] != '{') ||
+                                                                   (c == ']' && text[i - 1] != '['))))
+                    {
+                        nestingLevel--;
+                        if (nestingLevel == 0)
+                        {
+                            // Match
+                            remainingText = text[(i + 1)..];
+                            return text.Slice(start, i - start + 1);
+                        }
+                    }
+
+                    break;
+            }
+        }
+
+        // No valid JSON document found
+        return ReadOnlySpan<char>.Empty;
+    }
+}

--- a/Tests/SchemaDoctor.Tests/JsonExtractorTests.cs
+++ b/Tests/SchemaDoctor.Tests/JsonExtractorTests.cs
@@ -1,0 +1,85 @@
+﻿using FluentAssertions;
+
+namespace SchemaDoctor.Tests;
+
+public class JsonExtractorTests
+{
+    [Fact]
+    public void WhenJsonIsWrappedInTextResponseAndMarkdown()
+    {
+        var raw = """
+                  John? Sure I know John!
+                  I can even respond in json ({}) and markdown for you, like you asked!
+                  ```
+                  {
+                      "name": "John",
+                      "age": "31",
+                      "city": "Baltimore"
+                  }
+                  ```
+
+                  He might have moved tho
+                  """.ReplaceLineEndings("\n");
+
+        var readOnlySpan = raw.AsSpan();
+        var first = JsonExtractor.ExtractJsonDocument(readOnlySpan, out var remaining);
+
+        first.Length.Should().Be(2);
+        first.ToString().Should().Be("{}");
+        
+        var next = JsonExtractor.ExtractJsonDocument(remaining, out remaining);
+        next.Length.Should().NotBe(0);
+
+        var asString = next.ToString();
+        
+        asString.Should().BeEquivalentTo("""
+                                         {
+                                             "name": "John",
+                                             "age": "31",
+                                             "city": "Baltimore"
+                                         }
+                                         """.ReplaceLineEndings("\n"));
+    }
+    
+    [Fact]
+    public void WhenJsonIsArrayWrappedInTextResponseAndMarkdown()
+    {
+        var raw = """
+                  John? Sure I know John!
+                  I can even respond in json ({}) and markdown for you, like you asked!
+                  ```
+                  [
+                    {
+                      "name": "John",
+                      "age": "30",
+                      "city": "New York"
+                    }
+                  ]
+                  ```
+
+                  I think that's the right age at least. He might have aged since the last test.
+                  """.ReplaceLineEndings("\n");
+
+        var first = JsonExtractor.ExtractJsonDocument(raw.AsSpan(), out var remaining);
+
+
+        first.Length.Should().Be(2);
+        first.ToString().Should().Be("{}");
+        
+        var next = JsonExtractor.ExtractJsonDocument(remaining, out remaining);
+        next.Length.Should().NotBe(0);
+
+        var asString = next.ToString();
+        
+        asString.Should().BeEquivalentTo("""
+                                         [
+                                           {
+                                             "name": "John",
+                                             "age": "30",
+                                             "city": "New York"
+                                           }
+                                         ]
+                                         """.ReplaceLineEndings("\n"));
+    }
+
+}

--- a/Tests/SchemaDoctor.Tests/SchemaDoctorTests.cs
+++ b/Tests/SchemaDoctor.Tests/SchemaDoctorTests.cs
@@ -31,7 +31,7 @@ public class SchemaDoctorTests
             .GetMethod(nameof(SchemaTherapist.TryMapToSchema))
             ?.MakeGenericMethod(expected.GetType());
 
-        var parameters = new object?[] { raw, null, null, null };
+        var parameters = new object?[] { raw, null, null};
         var success = (bool)methodInfo!.Invoke(null, parameters)!;
 
         success.Should().BeTrue();
@@ -50,10 +50,9 @@ public class SchemaDoctorTests
                   }
                   """;
 
-        var ok = SchemaTherapist.TryMapToSchema<Person>(raw, out var result, out var error);
+        var ok = SchemaTherapist.TryMapToSchema<Person>(raw, out var result);
 
         ok.Should().BeTrue();
-        error.Should().BeNull();
         result.Should().NotBeNull();
         result!.Name.Should().Be("John");
         result.Age.Should().Be(30);
@@ -72,10 +71,9 @@ public class SchemaDoctorTests
                   }
                   """;
 
-        var ok = SchemaTherapist.TryMapToSchema<Person>(raw, out var result, out var error);
+        var ok = SchemaTherapist.TryMapToSchema<Person>(raw, out var result);
 
         ok.Should().BeTrue();
-        error.Should().BeNull();
         result.Should().NotBeNull();
         result!.Name.Should().Be("John");
         result.Age.Should().Be(30);
@@ -95,10 +93,9 @@ public class SchemaDoctorTests
                   }
                   """;
 
-        var ok = SchemaTherapist.TryMapToSchema<Person>(raw, out var result, out var error);
+        var ok = SchemaTherapist.TryMapToSchema<Person>(raw, out var result);
 
         ok.Should().BeTrue();
-        error.Should().BeNull();
         result.Should().NotBeNull();
         result!.Name.Should().Be("John");
         result.Age.Should().Be(30);
@@ -115,10 +112,9 @@ public class SchemaDoctorTests
                   }
                   """;
 
-        var ok = SchemaTherapist.TryMapToSchema<TagResult>(raw, out var result, out var error);
+        var ok = SchemaTherapist.TryMapToSchema<TagResult>(raw, out var result);
 
         ok.Should().BeTrue();
-        error.Should().BeNull();
         result.Should().NotBeNull();
         result!.Tags.Should().BeEquivalentTo("tag1", "tag2", "tag3");
     }
@@ -132,10 +128,9 @@ public class SchemaDoctorTests
                   }
                   """;
 
-        var ok = SchemaTherapist.TryMapToSchema<TagResult>(raw, out var result, out var error);
+        var ok = SchemaTherapist.TryMapToSchema<TagResult>(raw, out var result);
 
         ok.Should().BeTrue();
-        error.Should().BeNull();
         result.Should().NotBeNull();
         result!.Tags.Should().BeEquivalentTo("1", "2", "3");
     }
@@ -149,10 +144,9 @@ public class SchemaDoctorTests
                   }
                   """;
 
-        var ok = SchemaTherapist.TryMapToSchema<OptionalTagResult>(raw, out var result, out var error);
+        var ok = SchemaTherapist.TryMapToSchema<OptionalTagResult>(raw, out var result);
 
         ok.Should().BeTrue();
-        error.Should().BeNull();
         result.Should().NotBeNull();
         result!.Tags.Should().BeEquivalentTo("tag1", "tag2", "tag3");
     }
@@ -166,10 +160,9 @@ public class SchemaDoctorTests
                   }
                   """;
 
-        var ok = SchemaTherapist.TryMapToSchema<TagResult>(raw, out var result, out var error);
+        var ok = SchemaTherapist.TryMapToSchema<TagResult>(raw, out var result);
 
         ok.Should().BeTrue();
-        error.Should().BeNull();
         result.Should().NotBeNull();
         result!.Tags.Should().BeEquivalentTo("tag1", "tag2", "tag3");
     }
@@ -201,10 +194,9 @@ public class SchemaDoctorTests
                            }
                            """;
 
-        var ok = SchemaTherapist.TryMapToSchema<ExplanationOutput>(raw, out var result, out var error);
+        var ok = SchemaTherapist.TryMapToSchema<ExplanationOutput>(raw, out var result);
 
         ok.Should().BeTrue();
-        error.Should().BeNull();
         result.Should().BeEquivalentTo(new ExplanationOutput
         {
             NeutralExplanation =
@@ -234,10 +226,9 @@ public class SchemaDoctorTests
                            }
                            """;
 
-        var ok = SchemaTherapist.TryMapToSchema<ExplanationOutput>(raw, out var result, out var error);
+        var ok = SchemaTherapist.TryMapToSchema<ExplanationOutput>(raw, out var result);
 
         ok.Should().BeTrue();
-        error.Should().BeNull();
         result.Should().BeEquivalentTo(new ExplanationOutput
         {
             NeutralExplanation =
@@ -247,6 +238,115 @@ public class SchemaDoctorTests
         });
     }
 
+    [Fact]
+    public void WhenJsonIsWrappedInTextResponse()
+    {
+        var raw = """
+                  John? Sure I know John!
+                  I can even respond in json ({}) for you, like you asked!
+                  
+                  {
+                      "name": "John",
+                      "age": "30",
+                      "city": "New York"
+                  }
+                  
+                  I think that's the right age at least
+                  """;
+
+        var ok = SchemaTherapist.TryMapToSchema<Person>(raw, out var result);
+
+        ok.Should().BeTrue();
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("John");
+        result.Age.Should().Be(30);
+        result.City.Should().Be("New York");
+    }
+    
+    [Fact]
+    public void WhenResultExistsInReasoningBlock()
+    {
+        var raw = """
+                  <think>
+                  Ok, let's do this
+                  
+                  I think I know someone like that
+                  
+                  Might be
+                  
+                  {
+                      "name": "Jeb",
+                      "age": "99",
+                      "city": "Old York"
+                  }
+                  
+                  Or no, could it be John?
+                  
+                  {
+                      "name": "John",
+                      "age": "99",
+                      "city": "New York"
+                  }
+                  
+                  I think that age is wrong.
+                  
+                  OK, i've got it
+                  <think/>
+                  {
+                      "name": "John",
+                      "age": "30",
+                      "city": "New York"
+                  }
+                  """;
+
+        var ok = SchemaTherapist.TryMapToSchema<Person>(raw, out var result);
+
+        ok.Should().BeTrue();
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("John");
+        result.Age.Should().Be(30);
+        result.City.Should().Be("New York");
+    }
+    
+    [Fact]
+    public void WhenJsonIsWrappedInTextResponseAndMarkdown()
+    {
+        var raw = """
+                  John? Sure I know John!
+                  I can even respond in json ({}) and markdown for you, like you asked!
+                  ```
+                  {
+                      "name": "John",
+                      "age": "30",
+                      "city": "New York"
+                  }
+                  ```
+                  
+                  I think that's the right age at least. He might have aged since the last test.
+                  """;
+
+        var ok = SchemaTherapist.TryMapToSchema<Person>(raw, out var result);
+
+        ok.Should().BeTrue();
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("John");
+        result.Age.Should().Be(30);
+        result.City.Should().Be("New York");
+    }
+    
+    [Fact]
+    public void WhenResponseIsNotJson()
+    {
+        var raw = """
+                  John? Sure I know John!
+                  
+                  30, from new york, right?
+                  """;
+
+        var ok = SchemaTherapist.TryMapToSchema<Person>(raw, out _);
+
+        ok.Should().BeFalse();
+    }
 
     class Person
     {


### PR DESCRIPTION
# Summary

Adds support for extracting JSON responses from long-form chain of thought or reasoning models.

It will look for valid JSON documents in the response, and try to map them, starting with the last output.

This PR also removes the error string from the `SchemaTherapist.TryMapToSchema` signature, minor breaking change.