### PR TITLE
Upgrade dependencies to latest stable versions

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -31,6 +31,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Update="Microsoft.SourceLink.GitHub" PrivateAssets="All" Version="10.0.103" />
+        <PackageReference Update="Microsoft.SourceLink.GitHub" PrivateAssets="All" Version="10.0.300" />
     </ItemGroup>
 </Project>

--- a/Source/SchemaDoctor.Microsoft.Extensions.AI/SchemaDoctor.Microsoft.Extensions.AI.csproj
+++ b/Source/SchemaDoctor.Microsoft.Extensions.AI/SchemaDoctor.Microsoft.Extensions.AI.csproj
@@ -10,7 +10,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.AI" Version="10.3.0" />
+        <PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
     </ItemGroup>
 
 </Project>

--- a/Source/SchemaDoctor/SchemaDoctor.csproj
+++ b/Source/SchemaDoctor/SchemaDoctor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <PackageReference Include="NJsonSchema" Version="11.5.2" />
+        <PackageReference Include="NJsonSchema" Version="11.6.1" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgrades NuGet dependencies to their latest stable releases.

## Changes

| Package | Old | New |
|---|---|---|
| NJsonSchema | 11.5.2 | 11.6.1 |
| Microsoft.Extensions.AI | 10.3.0 | 10.7.0 |
| Microsoft.SourceLink.GitHub | 10.0.103 | 10.0.300 |

`AwesomeAssertions` (9.4.0) and `xunit.v3` (3.2.2) were already at their latest stable versions and are unchanged (xunit.v3 4.0.0 is prerelease, so it was skipped).

## Verification

- `dotnet build -c Release` — 0 warnings, 0 errors across `net8.0`, `net9.0`, `net10.0` (note `TreatWarningsAsErrors` is enabled)
- Tests pass on all three target frameworks: **61/61** on net8.0, net9.0, and net10.0
- `dotnet pack -c Release` produces all `.nupkg`/`.snupkg` packages cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuWneSSZac6y9n5gffmU1e)_